### PR TITLE
chore: use process.env in addition to .env.local for edit mode

### DIFF
--- a/packages/blink/src/react/use-dev-mode.ts
+++ b/packages/blink/src/react/use-dev-mode.ts
@@ -176,12 +176,11 @@ export default function useDevMode(options: UseDevModeOptions): UseDevMode {
       ...dotenv,
     }
     if (blinkToken) {
-      return {
-        ...allEnv,
-        BLINK_TOKEN: blinkToken,
-      };
+      allEnv.BLINK_TOKEN = blinkToken;
     }
-    return allEnv;
+    return Object.fromEntries(
+      Object.entries(allEnv).filter(([_, value]) => value !== undefined)
+    ) as Record<string, string>;
   }, [dotenv, auth.token]);
 
   // Track env changes


### PR DESCRIPTION
This will allow for using env vars set by default in a Coder workspace for AI Bridge