### PR TITLE
fix: access page bugs - selection loss, pagination, and sorting

### DIFF
--- a/internal/api/src/routes/agents/members.client.ts
+++ b/internal/api/src/routes/agents/members.client.ts
@@ -37,6 +37,7 @@ export type AgentMember = z.infer<typeof schemaAgentMember>;
 
 export const schemaListAgentMembersRequest = schemaPaginatedRequest.extend({
   agent_id: z.uuid(),
+  order_by: z.enum(["permission", "name", "created_at"]).optional(),
 });
 
 export type ListAgentMembersRequest = z.infer<
@@ -95,6 +96,9 @@ export default class AgentMembers {
     }
     if (request.page) {
       query.set("page", request.page.toString());
+    }
+    if (request.order_by) {
+      query.set("order_by", request.order_by);
     }
     const resp = await this.client.request(
       "GET",

--- a/internal/api/src/routes/agents/members.server.ts
+++ b/internal/api/src/routes/agents/members.server.ts
@@ -26,10 +26,16 @@ export default function mountAgentMembers(server: APIServer) {
     async (c) => {
       const db = await c.env.database();
       const agent = c.get("agent");
+      const orderBy = c.req.query("order_by") as
+        | "permission"
+        | "name"
+        | "created_at"
+        | undefined;
       const members = await db.selectAgentPermissions({
         agentId: agent.id,
         page: c.get("page"),
         per_page: c.get("per_page"),
+        orderBy,
       });
       const resp: ListAgentMembersResponse = {
         has_more: members.has_more,

--- a/internal/api/src/routes/organizations/members.client.ts
+++ b/internal/api/src/routes/organizations/members.client.ts
@@ -45,6 +45,7 @@ export type OrganizationMember = z.infer<typeof schemaOrganizationMember>;
 const schemaListOrganizationMembersRequest = schemaPaginatedRequest.extend({
   organization_id: z.uuid(),
   query: z.string().optional(),
+  order_by: z.enum(["role", "name", "created_at"]).optional(),
 });
 
 export type ListOrganizationMembersRequest = z.infer<
@@ -112,6 +113,9 @@ export default class OrganizationMembers {
     }
     if (request.query) {
       query.set("query", request.query);
+    }
+    if (request.order_by) {
+      query.set("order_by", request.order_by);
     }
     const resp = await this.client.request(
       "GET",

--- a/internal/api/src/routes/organizations/members.server.ts
+++ b/internal/api/src/routes/organizations/members.server.ts
@@ -25,11 +25,17 @@ export default function mountMembers(server: APIServer) {
     async (c) => {
       const db = await c.env.database();
       const query = c.req.query("query");
+      const orderBy = c.req.query("order_by") as
+        | "role"
+        | "name"
+        | "created_at"
+        | undefined;
       const members = await db.selectOrganizationMembers({
         organizationID: c.get("organization").id,
         page: c.get("page"),
         per_page: c.get("per_page"),
         query: query || undefined,
+        orderBy,
       });
       const resp: ListOrganizationMembersResponse = {
         has_more: members.has_more,


### PR DESCRIPTION
## Summary

Fixes several bugs on the access page:

### 1. UserSelector loses selection on close
**Root cause:** `selectedMember` was computed by looking up `selectedUserId` in `orgMembers`, but `orgMembers` changes based on search query. When dropdown closes, search is cleared, API refetches, and if selected user isn't in first page of results, selection disappears.

**Fix:** Cache the selected member object when selection is made, use cached value for display.

### 2. Member list shows only ~10 people
**Root cause:** API returns paginated results (default `per_page=10`) and frontend doesn't handle pagination.

**Fix:** Implement proper pagination with `per_page=20` and Previous/Next controls.

### 3. No sorting support
**Fix:** Added `order_by` parameter to both organization and agent members APIs:
- Organization members: `role` (owner > admin > billing_admin > member), `name`, `created_at`
- Agent members: `permission` (admin > write > read), `name`, `created_at`

## Changes

| File | Changes |
|------|---------|
| `user-selector.tsx` | Cache selected member; use `per_page: 50`, `order_by: "name"` |
| `agent-access-client.tsx` | Use `per_page: 20`, `order_by` sorting, pagination UI |
| `agents/members.client.ts` | Add `order_by` to schema and client |
| `agents/members.server.ts` | Parse `order_by` query param |
| `organizations/members.client.ts` | Add `order_by` to schema and client |
| `organizations/members.server.ts` | Parse `order_by` query param |
| `database/src/querier.ts` | Add sorting logic with `CASE WHEN` for hierarchy |
