### PR TITLE
feat(api): add order direction support to member list endpoints

### DIFF
--- a/internal/api/src/routes/agents/members.client.ts
+++ b/internal/api/src/routes/agents/members.client.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   assertResponseStatus,
+  schemaOrderBy,
   schemaPaginatedRequest,
   schemaPaginatedResponse,
 } from "../../client-helper";
@@ -35,9 +36,11 @@ export const schemaAgentMember = schemaAgentPermission.extend({
 
 export type AgentMember = z.infer<typeof schemaAgentMember>;
 
+const agentMemberOrderFields = ["permission", "name", "created_at"] as const;
+
 export const schemaListAgentMembersRequest = schemaPaginatedRequest.extend({
   agent_id: z.uuid(),
-  order_by: z.enum(["permission", "name", "created_at"]).optional(),
+  order_by: schemaOrderBy(agentMemberOrderFields).optional(),
 });
 
 export type ListAgentMembersRequest = z.infer<

--- a/internal/api/src/routes/agents/members.server.ts
+++ b/internal/api/src/routes/agents/members.server.ts
@@ -1,5 +1,6 @@
 import type { AgentPermission as DBAgentPermission } from "@blink.so/database/schema";
 import { validator } from "hono/validator";
+import { parseOrderBy } from "../../client-helper";
 import {
   withAgent,
   withAgentPermission,
@@ -26,16 +27,14 @@ export default function mountAgentMembers(server: APIServer) {
     async (c) => {
       const db = await c.env.database();
       const agent = c.get("agent");
-      const orderBy = c.req.query("order_by") as
-        | "permission"
-        | "name"
-        | "created_at"
-        | undefined;
+      const orderByParam = c.req.query("order_by");
+      const orderBy = parseOrderBy(orderByParam);
       const members = await db.selectAgentPermissions({
         agentId: agent.id,
         page: c.get("page"),
         per_page: c.get("per_page"),
-        orderBy,
+        orderBy: orderBy?.field as "permission" | "name" | "created_at" | undefined,
+        orderDirection: orderBy?.direction,
       });
       const resp: ListAgentMembersResponse = {
         has_more: members.has_more,

--- a/internal/api/src/routes/organizations/members.client.ts
+++ b/internal/api/src/routes/organizations/members.client.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   assertResponseStatus,
+  schemaOrderBy,
   schemaPaginatedRequest,
   schemaPaginatedResponse,
 } from "../../client-helper";
@@ -42,10 +43,12 @@ const schemaOrganizationMember = schemaOrganizationMembership.extend({
 
 export type OrganizationMember = z.infer<typeof schemaOrganizationMember>;
 
+const orgMemberOrderFields = ["role", "name", "created_at"] as const;
+
 const schemaListOrganizationMembersRequest = schemaPaginatedRequest.extend({
   organization_id: z.uuid(),
   query: z.string().optional(),
-  order_by: z.enum(["role", "name", "created_at"]).optional(),
+  order_by: schemaOrderBy(orgMemberOrderFields).optional(),
 });
 
 export type ListOrganizationMembersRequest = z.infer<

--- a/internal/api/src/routes/organizations/members.server.ts
+++ b/internal/api/src/routes/organizations/members.server.ts
@@ -3,6 +3,7 @@ import type {
   UserWithPersonalOrganization,
 } from "@blink.so/database/schema";
 import { validator } from "hono/validator";
+import { parseOrderBy } from "../../client-helper";
 import {
   withAuth,
   withOrganizationURLParam,
@@ -25,17 +26,15 @@ export default function mountMembers(server: APIServer) {
     async (c) => {
       const db = await c.env.database();
       const query = c.req.query("query");
-      const orderBy = c.req.query("order_by") as
-        | "role"
-        | "name"
-        | "created_at"
-        | undefined;
+      const orderByParam = c.req.query("order_by");
+      const orderBy = parseOrderBy(orderByParam);
       const members = await db.selectOrganizationMembers({
         organizationID: c.get("organization").id,
         page: c.get("page"),
         per_page: c.get("per_page"),
         query: query || undefined,
-        orderBy,
+        orderBy: orderBy?.field as "role" | "name" | "created_at" | undefined,
+        orderDirection: orderBy?.direction,
       });
       const resp: ListOrganizationMembersResponse = {
         has_more: members.has_more,


### PR DESCRIPTION
## Summary

This PR adds proper backend sorting support to the member list endpoints, moving sorting from frontend-only to API-driven.

### API Convention

Uses `-` prefix for descending order (common pattern in Django REST, JSON:API, Stripe):

```
GET /api/agents/{id}/members?order_by=permission      # ascending by permission
GET /api/agents/{id}/members?order_by=-permission     # descending by permission
GET /api/agents/{id}/members?order_by=-created_at     # newest first
```

### Changes

**API (`internal/api`)**
- Added `schemaOrderBy()` helper in `client-helper.ts` - creates a reusable sorting schema that accepts `'field'` or `'-field'` format
- Added `parseOrderBy()` helper to parse the order_by value into `{ field, direction }`
- Updated `agents/members` endpoint to support order direction
- Updated `organizations/members` endpoint to support order direction

**Database (`internal/database`)**
- Updated `selectAgentPermissions` to accept `orderDirection` parameter
- Updated `selectOrganizationMembers` to accept `orderDirection` parameter

**Frontend (`internal/site`)**
- Moved sort state from `MembersTable` to `AgentAccessClient` so sorting triggers API refetch
- `MembersTable` now receives `sortField`, `sortDirection`, and `onSort` as props
- "Member" and "Permission" columns use backend API sorting
- "Source" column remains frontend-only (it combines explicit + implicit members which come from different APIs)

### Usage Example

Endpoints can opt into sorting by using the helper:

```typescript
import { schemaOrderBy, parseOrderBy } from '../../client-helper';

// In client schema
const schema = schemaPaginatedRequest.extend({
  order_by: schemaOrderBy(['name', 'created_at', 'permission']).optional(),
});

// In server handler
const orderBy = parseOrderBy(c.req.query('order_by'));
// orderBy = { field: 'name', direction: 'desc' } for '-name'
```

### Testing

- Verified TypeScript compiles without errors
- API backwards compatible (ascending is default when no `-` prefix)