### PR TITLE
fix(site): message flash on first chat message

### DIFF
--- a/internal/site/components/agent-chat.tsx
+++ b/internal/site/components/agent-chat.tsx
@@ -649,7 +649,8 @@ export default function AgentChat({
               showTimestamp={false}
               canEditMessage={false}
               isStreaming={
-                status === "streaming" && index === messages.length - 1
+                (status === "streaming" || status === "submitted") &&
+                index === messages.length - 1
               }
               isLatestMessage={index === messages.length - 1}
               chatId={""}


### PR DESCRIPTION
## Summary

- Fix user message briefly disappearing when sending the first message to a new chat
- Fix action buttons (copy, link, bug) flashing when user message appears

## Details

**Message disappearing**: When creating a new chat with `stream: true`, `responseMessages` is empty because messages arrive via the stream. The deduplication logic was removing the pre-inserted user message before any replacement arrived. Now we only remove pre-inserted messages when we have server-assigned replacements.

**Buttons flashing**: Action buttons were shown during the `"submitted"` status because `isStreaming` only checked for `"streaming"`. Now buttons are hidden for the latest message during both `"submitted"` and `"streaming"` states.