### PR TITLE
feat(server): add dev proxy mode for Next.js + db fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .next
 **/tsconfig.tsbuildinfo
 .wrangler
+.blink

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,7 +23,8 @@
   "type": "module",
   "scripts": {
     "build": "bun scripts/build.ts",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "dev": "bun src/cli.ts --dev"
   },
   "devDependencies": {
     "blink": "workspace:*",

--- a/packages/server/src/postgres.ts
+++ b/packages/server/src/postgres.ts
@@ -116,6 +116,8 @@ async function createAndStartContainer(): Promise<void> {
     `POSTGRES_DB=${POSTGRES_DB}`,
     "-p",
     `${POSTGRES_PORT}:5432`,
+    "-v",
+    "blink-server-postgres-data:/var/lib/postgresql/data",
     "pgvector/pgvector:pg17",
   ]);
 


### PR DESCRIPTION
- Add `--dev` flag to proxy frontend requests to a separate Next.js dev server instead of running Next.js in-memory
- Cache database querier to reuse connections - since Blink is not serverless anymore, we were creating - and never closing - a new connection on every request
- Persist Postgres data with Docker volume