### PR TITLE
fix(server): eliminate port race condition in Docker networking check

### DIFF
--- a/packages/server/src/check-docker-networking.test.ts
+++ b/packages/server/src/check-docker-networking.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { checkDockerNetworking } from "./check-docker-networking";
+
+async function isDockerAvailable(): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["docker", "info"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    const code = await proc.exited;
+    return code === 0;
+  } catch {
+    return false;
+  }
+}
+
+describe("checkDockerNetworking", async () => {
+  const dockerAvailable = await isDockerAvailable();
+
+  test.skipIf(!dockerAvailable)(
+    "should detect networking capabilities",
+    async () => {
+      const result = await checkDockerNetworking();
+
+      // If host networking works both ways, hostAddress should be set
+      if (result.hostNetwork.containerToHost) {
+        expect(result.hostNetwork.hostAddress).not.toBeNull();
+      }
+
+      // If port-bind works both ways, hostAddress should be set
+      if (result.portBind.containerToHost) {
+        expect(result.portBind.hostAddress).not.toBeNull();
+      }
+
+      // Verify recommendation is consistent with results
+      const hostWorks =
+        result.hostNetwork.hostToContainer &&
+        result.hostNetwork.containerToHost;
+      const bridgeWorks =
+        result.portBind.hostToContainer && result.portBind.containerToHost;
+
+      if (hostWorks && bridgeWorks) {
+        expect(result.recommended).toBe("both");
+      } else if (hostWorks) {
+        expect(result.recommended).toBe("host");
+      } else if (bridgeWorks) {
+        expect(result.recommended).toBe("port-bind");
+      } else {
+        expect(result.recommended).toBe("none");
+      }
+    },
+    { timeout: 30000 }
+  );
+});


### PR DESCRIPTION
The previous implementation used `getRandomPort()` which created a race condition - another process could bind to the port between when we discovered it and when the Docker container tried to use it.

Now containers bind to port 0 themselves and we query the assigned port:
- Host network: parse port from `docker logs` (container logs `BLINK_PORT:<port>`)
- Port-bind mode: use `-p 0:3000` and query with `docker port`