### PR TITLE
fix(site): move tailwind import to the top of styles.css

### DIFF
--- a/internal/site/app/(public)/styles.css
+++ b/internal/site/app/(public)/styles.css
@@ -1,3 +1,8 @@
+/* Self-contained CSS for the public site */
+/* Extracted from globals.css to decouple public site styles */
+
+@import "tailwindcss" source("../..");
+
 @font-face {
   font-family: "LayGrotesk";
   src: url("/fonts/LayGrotesk-Regular.woff2") format("woff2");
@@ -13,10 +18,6 @@
   font-style: normal;
   font-display: swap;
 }
-/* Self-contained CSS for the public site */
-/* Extracted from globals.css to decouple public site styles */
-
-@import "tailwindcss" source("../..");
 
 /* Enable smooth scrolling for anchor links */
 html {


### PR DESCRIPTION
fixes this warning in storybook

```
7:40:07 PM [vite] (client) hmr update /app/globals.css, /@id/__x00__virtual:/@storybook/builder-vite/vite-app.js (x2)
[vite:css][postcss] @import must precede all other statements (besides @charset or empty @layer)
17 |  /* Extracted from globals.css to decouple public site styles */
18 |  
19 |  @import "tailwindcss" source("../..");
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
20 |  
21 |  /* Enable smooth scrolling for anchor links */
```