### PR TITLE
fix(site): remove duplicate Tailwind import from public styles

### DIFF
--- a/internal/site/app/(public)/styles.css
+++ b/internal/site/app/(public)/styles.css
@@ -1,7 +1,5 @@
-/* Self-contained CSS for the public site */
-/* Extracted from globals.css to decouple public site styles */
-
-@import "tailwindcss" source("../..");
+/* Public site specific styles */
+/* Supplements globals.css with public-site fonts, animations, and theme overrides */
 
 @font-face {
   font-family: "LayGrotesk";


### PR DESCRIPTION
Removes `@import "tailwindcss"` from `styles.css` to fix CSS conflicts in Storybook.

Both `globals.css` (root layout) and `styles.css` (public layout) were importing Tailwind separately, causing the second bundle to overwrite base styles like border colors and fonts.