### PR TITLE
feat(cli): support custom host URL in blink login

### DIFF
--- a/packages/blink/src/cli/chat.ts
+++ b/packages/blink/src/cli/chat.ts
@@ -1,11 +1,14 @@
 import open from "open";
 import { WebSocket } from "ws";
 import { WorkspaceConnect } from "./connect";
+import { getHost, toWsUrl } from "./lib/auth";
 import { openUrl } from "./lib/util";
 
 export default async function chat() {
+  const host = getHost();
+  const wsHost = toWsUrl(host);
   const id = crypto.randomUUID();
-  const ws = new WebSocket(`wss://blink.so/legacy-auth?id=${id}`);
+  const ws = new WebSocket(`${wsHost}/legacy-auth?id=${id}`);
   const opened = new Promise<void>((resolve, reject) => {
     ws.onopen = () => {
       resolve();
@@ -20,14 +23,14 @@ export default async function chat() {
       resolve(event.data.toString());
     };
   });
-  const url = `https://blink.coder.com/legacy-auth?id=${id}&type=workspace`;
+  const url = `${host}/legacy-auth?id=${id}&type=workspace`;
   console.log(`Opening the following URL in your browser: ${url}`);
   await openUrl(url);
 
   const token = await tokenPromise;
 
   const srv = new WorkspaceConnect({
-    url: "wss://blink.so/api/connect",
+    url: `${wsHost}/api/connect`,
     token,
   });
   srv.onConnect(() => {

--- a/packages/blink/src/cli/connect.ts
+++ b/packages/blink/src/cli/connect.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import WebSocket from "ws";
+import { getHost, toWsUrl } from "./lib/auth";
 
 // Tempfile logger
 const tempLogPath = path.join(os.tmpdir(), `blink-connect-${process.pid}.log`);
@@ -54,13 +55,14 @@ export default async function connect() {
     reportException(token!, err);
   });
 
+  const host = getHost();
   const srv = new WorkspaceConnect({
-    url: url ?? "wss://blink.so/api/connect",
+    url: url ?? `${toWsUrl(host)}/api/connect`,
     token,
     createDeploymentFromTar: async (tar) => {
       const uploadURL = new URL(
         "/api/static-deployment",
-        url ?? "https://blink.coder.com"
+        url ?? host
       );
       const response = await fetch(uploadURL, {
         method: "POST",
@@ -87,7 +89,7 @@ export default async function connect() {
 }
 
 const reportException = async (token: string, err: unknown) => {
-  const url = new URL("https://blink.coder.com/api/connect-error");
+  const url = new URL(`${getHost()}/api/connect-error`);
   await fetch(url.toString(), {
     method: "POST",
     headers: {

--- a/packages/blink/src/cli/deploy.ts
+++ b/packages/blink/src/cli/deploy.ts
@@ -4,7 +4,7 @@ import Client, {
 } from "@blink.so/api";
 import { stat, readFile } from "node:fs/promises";
 import { basename, dirname, join, relative } from "node:path";
-import { loginIfNeeded } from "./lib/auth";
+import { getHost, loginIfNeeded } from "./lib/auth";
 import { migrateDataToBlink } from "./lib/migrate";
 import { existsSync } from "node:fs";
 import { mkdir, writeFile, readdir } from "fs/promises";
@@ -364,7 +364,7 @@ export default async function deploy(
     });
     deployConfig.agentId = agent.id;
     agentName = agent.name;
-    const agentUrl = `https://blink.coder.com/${organizationName}/${agentName}`;
+    const agentUrl = `${getHost()}/${organizationName}/${agentName}`;
     console.log(chalk.gray(`Agent created ${chalk.dim(agentUrl)}`));
   } else if (envEntries.length > 0) {
     // Update environment variables for existing agents
@@ -437,7 +437,7 @@ export default async function deploy(
         message: options?.message,
       });
 
-  const inspectUrl = `https://blink.coder.com/${organizationName}/${agentName}/deployments/${deployment.number}`;
+  const inspectUrl = `${getHost()}/${organizationName}/${agentName}/deployments/${deployment.number}`;
 
   // Show deployment URL immediately
   console.log(chalk.gray(`View Deployment ${chalk.dim(inspectUrl)}`));

--- a/packages/blink/src/cli/index.ts
+++ b/packages/blink/src/cli/index.ts
@@ -129,8 +129,8 @@ program
   .action(asyncEntry(() => import("./chat")));
 
 program
-  .command("login")
-  .description("Log in to the Blink Cloud.")
+  .command("login [url]")
+  .description("Log in to the Blink Cloud. Optionally specify a custom host URL.")
   .action(asyncEntry(() => import("./login")));
 
 const computeCommand = program

--- a/packages/blink/src/cli/login.ts
+++ b/packages/blink/src/cli/login.ts
@@ -1,5 +1,5 @@
 import { login as loginFn } from "./lib/auth";
 
-export default async function login() {
-  await loginFn();
+export default async function login(url?: string) {
+  await loginFn(url);
 }

--- a/packages/blink/src/cli/setup-github-app.ts
+++ b/packages/blink/src/cli/setup-github-app.ts
@@ -12,6 +12,7 @@ import {
 import chalk from "chalk";
 import type { GitHubAppData } from "../edit/tools/create-github-app";
 import { createGithubApp } from "../edit/tools/create-github-app";
+import { getHost } from "./lib/auth";
 import { createDevhookID, getDevhookID, hasDevhook } from "./lib/devhook";
 import { openUrl } from "./lib/util";
 
@@ -115,7 +116,7 @@ export async function setupGithubApp(
   // Create manifest with sensible defaults for a typical GitHub App
   const manifest = {
     name: githubAppName.toString(),
-    url: "https://blink.coder.com",
+    url: getHost(),
     description: "A Blink agent for GitHub",
     public: false,
     hook_attributes: {

--- a/packages/blink/src/cli/setup-slack-app.ts
+++ b/packages/blink/src/cli/setup-slack-app.ts
@@ -3,6 +3,7 @@ import { access, readdir, readFile, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import util from "node:util";
 import Client from "@blink.so/api";
+import { getHost } from "./lib/auth";
 import {
   confirm,
   intro,
@@ -214,7 +215,7 @@ export async function setupSlackApp(
   let lastFailedChannel: string | undefined;
 
   const client = new Client({
-    baseURL: "https://blink.coder.com",
+    baseURL: getHost(),
   });
 
   let resolveConnected = () => {};


### PR DESCRIPTION
## Summary
Allow `blink login` to accept an optional host URL argument (defaulting to `blink.coder.com`), store it alongside the auth token, and reuse it across all CLI commands.

## Changes
- Extended `auth.ts` config format from `{token}` to `{token, host}`
- Added `getHost()` function with priority: `BLINK_HOST` env var → config file → default
- Added `setHost()`, `normalizeHost()`, and `toWsUrl()` helper functions
- Updated `login` command to accept optional `[url]` argument
- Updated `deploy.ts`, `connect.ts`, `chat.ts` to use `getHost()`
- Updated `setup-github-app.ts` and `setup-slack-app.ts` to use `getHost()`

## Usage Examples
```bash
# Login to default host (blink.coder.com)
blink login

# Login to custom host
blink login https://my-blink.example.com
blink login my-blink.example.com  # https:// auto-added

# Override via environment variable (useful for CI)
BLINK_HOST=https://staging.blink.coder.com blink deploy
```

## Config File Format (After)
**Path:** `~/.local/share/blink/auth.json` (XDG)
```json
{
  "_": "This is your Blink credentials file. DO NOT SHARE THIS FILE WITH ANYONE!",
  "token": "eyJhbG...",
  "host": "https://my-blink.example.com"
}
```

## Testing
- `blink` package typechecks successfully with `bun run typecheck`