### PR TITLE
fix(cli): add missing baseURL to deploy.ts Client

### DIFF
--- a/packages/blink/src/cli/deploy.ts
+++ b/packages/blink/src/cli/deploy.ts
@@ -34,6 +34,7 @@ export default async function deploy(
 
   const token = await loginIfNeeded();
   const client = new Client({
+    baseURL: getHost(),
     authToken: token,
     // @ts-ignore - This is just because of Bun.
     fetch: (url, init) => {


### PR DESCRIPTION
## Problem
The `Client` in `deploy.ts` was not using `getHost()`, causing all deployments to go to the default `blink.coder.com` host even when a custom host was configured via `blink login <url>`.

## Fix
Added `baseURL: getHost()` to the Client constructor in deploy.ts.

This is a follow-up fix to PR #157.