### PR TITLE
fix(server): close ws connection after sending auth token

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -202,6 +202,7 @@ export async function startServer(options: ServerOptions) {
                     data.id === id
                   ) {
                     client.send(token);
+                    client.close();
                   }
                 });
               },


### PR DESCRIPTION
Without the fix, the `blink login` command would hang after completing authentication on self-hosted deployments.

Matches the cloudflare worker behavior: https://github.com/coder/blink/blob/8ebf57a0fe33144d5aeae13b579b52d26fad47a3/internal/worker/src/command-line-auth.ts#L11