### PR TITLE
chore: run ci on depot runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout code
@@ -21,14 +21,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install
-
-      - name: Cache turbo
-        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
 
       - name: Build packages
         run: bun run build


### PR DESCRIPTION
Depot auto-configures turbo cache: https://depot.dev/docs/cache/integrations/turbo#depot-github-actions-runners