### PR TITLE
feat: redirect marketing pages to login in self-hosted mode

### DIFF
--- a/internal/site/middleware.ts
+++ b/internal/site/middleware.ts
@@ -97,6 +97,18 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  // In self-hosted mode, redirect unauthenticated users from marketing pages to login
+  const isSelfHosted = process.env.SELF_HOSTED === "true";
+  if (isSelfHosted && !token) {
+    const marketingPages = ["/", "/home", "/privacy", "/terms"];
+    const isMarketingPage = marketingPages.some(
+      (p) => pathname === p || pathname.startsWith(p + "/")
+    );
+    if (isMarketingPage) {
+      return NextResponse.redirect(new URL("/login", request.url));
+    }
+  }
+
   if (token && pathname === "/") {
     if (response) {
       // Preserve cookie migration in redirect
@@ -126,6 +138,9 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     "/",
+    "/home",
+    "/privacy",
+    "/terms/:path*",
     "/chat",
     "/chat/:id",
     "/api/:path*",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -623,6 +623,7 @@ const startNextServer = async (opts: StartNextServerOptions) => {
   }
   // This is required for Next to not freak out about not having a config.
   // Their standalone generated file does exactly this.
+  process.env.SELF_HOSTED = "true";
   process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(nextConfig);
 
   const next = customRequire("next") as typeof import("next").default;


### PR DESCRIPTION
In self-hosted mode, unauthenticated users visiting marketing pages are now redirected to `/login`.

## Changes

- Set `SELF_HOSTED=true` env var in `server.ts` before Next.js starts
- Add redirect logic in `middleware.ts` for marketing pages
- Update middleware matcher to include `/home`, `/privacy`, `/terms` routes

## Behavior

| Route | Cloud Mode | Self-Hosted (Unauthenticated) |
|-------|------------|-------------------------------|
| `/` | Marketing homepage | → `/login` |
| `/home` | Marketing homepage | → `/login` |
| `/privacy` | Privacy policy | → `/login` |
| `/terms/*` | Terms pages | → `/login` |
| `/login` | Sign in | No change |
| `/signup` | Sign up | No change |