### PR TITLE
fix(site): improve agent delete dialog spacing and mention chats

### DIFF
--- a/internal/site/app/(app)/[organization]/[agent]/settings/agent-delete-form.tsx
+++ b/internal/site/app/(app)/[organization]/[agent]/settings/agent-delete-form.tsx
@@ -92,13 +92,13 @@ export function AgentDeleteForm({
                 <DialogTitle>Are you absolutely sure?</DialogTitle>
                 <DialogDescription>
                   This action cannot be undone. This will permanently delete the
-                  agent <strong>{agentName}</strong> and remove all of its data,
-                  deployments, and configurations.
+                  agent <strong>{agentName}</strong> and remove all of its data
+                  including chats, deployments, and configurations.
                 </DialogDescription>
               </DialogHeader>
 
               <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="space-y-2">
+                <div className="space-y-3">
                   <label
                     htmlFor="agent-name-confirm"
                     className="text-sm font-medium"


### PR DESCRIPTION
## Summary
Small UX improvements to the agent deletion confirmation dialog.

## Changes
- **Added more padding** between the label text and the input field (`space-y-2` → `space-y-3`)
- **Updated description** to explicitly mention that chats are also deleted:
  > "...remove all of its data including **chats**, deployments, and configurations."

This makes it clear to users that deleting an agent will also delete all associated chat history.