### PR TITLE
feat: add generic OIDC authentication support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "blink-repo",
@@ -381,7 +382,7 @@
         "@biomejs/biome": "2.3.2",
         "@types/node": "latest",
         "ai": "^5.0.0",
-        "blink": "^1.1.35",
+        "blink": "^1.1.36",
         "esbuild": "latest",
         "msw": "^2.12.1",
         "tsdown": "^0.3.0",
@@ -1804,7 +1805,7 @@
 
     "@types/mysql": ["@types/mysql@2.15.27", "", { "dependencies": { "@types/node": "*" } }, "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA=="],
 
-    "@types/node": ["@types/node@25.0.8", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg=="],
+    "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 

--- a/internal/api/src/routes/auth/auth.server.test.ts
+++ b/internal/api/src/routes/auth/auth.server.test.ts
@@ -1007,6 +1007,532 @@ test("POST /resend-password-reset fails without cookie", async () => {
   expect(data.error).toContain("No reset session");
 });
 
+// ============================================================================
+// OIDC Tests
+// ============================================================================
+
+// Mock OIDC discovery response
+const mockOIDCDiscovery = {
+  issuer: "https://issuer.example.com",
+  authorization_endpoint: "https://issuer.example.com/authorize",
+  token_endpoint: "https://issuer.example.com/token",
+  userinfo_endpoint: "https://issuer.example.com/userinfo",
+};
+
+// Mock OIDC userinfo response
+const mockOIDCProfile = {
+  sub: "oidc-user-123",
+  email: "oidc@example.com",
+  name: "OIDC User",
+  preferred_username: "oidcuser",
+  picture: "https://issuer.example.com/avatar.jpg",
+  email_verified: true,
+};
+
+const mockOIDCTokenResponse = {
+  access_token: "mock-oidc-access-token",
+  token_type: "Bearer",
+  expires_in: 3600,
+  refresh_token: "mock-oidc-refresh-token",
+  id_token: "mock-oidc-id-token",
+  scope: "openid profile email",
+};
+
+test("GET /providers does not include OIDC when not configured", async () => {
+  const { url } = await serve();
+  const res = await fetch(`${url}/api/auth/providers`);
+  expect(res.status).toBe(200);
+
+  const data = await res.json();
+  expect(data.oidc).toBeUndefined();
+});
+
+test("GET /providers includes OIDC when configured", async () => {
+  const { url } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+    },
+  });
+  const res = await fetch(`${url}/api/auth/providers`);
+  expect(res.status).toBe(200);
+
+  const data = await res.json();
+  expect(data.oidc).toEqual({
+    id: "oidc",
+    name: "OpenID Connect",
+    type: "oidc",
+    signInText: undefined,
+    iconUrl: undefined,
+  });
+});
+
+test("GET /providers includes customized OIDC name and icon", async () => {
+  const { url } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+      OIDC_SIGN_IN_TEXT: "Sign in with Okta",
+      OIDC_ICON_URL: "https://okta.example.com/icon.svg",
+    },
+  });
+  const res = await fetch(`${url}/api/auth/providers`);
+  expect(res.status).toBe(200);
+
+  const data = await res.json();
+  expect(data.oidc).toEqual({
+    id: "oidc",
+    name: "Sign in with Okta",
+    type: "oidc",
+    signInText: "Sign in with Okta",
+    iconUrl: "https://okta.example.com/icon.svg",
+  });
+});
+
+test("GET /signin/oidc redirects to OIDC authorization endpoint", async () => {
+  // Mock OIDC discovery
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    )
+  );
+
+  const { url } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+    },
+  });
+
+  const res = await fetch(`${url}/api/auth/signin/oidc`, {
+    redirect: "manual",
+  });
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toStartWith("https://issuer.example.com/authorize");
+  expect(location).toContain("client_id=test-oidc-client-id");
+  expect(location).toContain("scope=openid+profile+email");
+  expect(location).toContain("state=");
+  expect(location).toContain("response_type=code");
+});
+
+test("GET /signin/oidc uses custom scopes when configured", async () => {
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    )
+  );
+
+  const { url } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+      OIDC_SCOPES: "openid email groups",
+    },
+  });
+
+  const res = await fetch(`${url}/api/auth/signin/oidc`, {
+    redirect: "manual",
+  });
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toContain("scope=openid+email+groups");
+});
+
+test("GET /signin/oidc applies extra auth URL params", async () => {
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    )
+  );
+
+  const { url } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+      OIDC_AUTH_URL_PARAMS: JSON.stringify({
+        prompt: "login",
+        acr_values: "urn:okta:loa:1fa:any",
+      }),
+    },
+  });
+
+  const res = await fetch(`${url}/api/auth/signin/oidc`, {
+    redirect: "manual",
+  });
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toContain("prompt=login");
+  expect(location).toContain("acr_values=urn%3Aokta%3Aloa%3A1fa%3Aany");
+});
+
+test("GET /signin/oidc without configuration redirects with error", async () => {
+  const { url } = await serve();
+
+  const res = await fetch(`${url}/api/auth/signin/oidc`, {
+    redirect: "manual",
+  });
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toContain("/login?error=oidc_not_configured");
+});
+
+test("GET /callback/oidc with missing code returns error", async () => {
+  const { url, bindings } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+    },
+  });
+
+  // Generate valid state
+  const { encode } = await import("next-auth/jwt");
+  const state = await encode({
+    secret: bindings.AUTH_SECRET,
+    salt: "oauth-state",
+    token: {
+      provider: "oidc",
+      nonce: "test-nonce",
+      callbackUrl: `${url}/api/auth/callback/oidc`,
+    },
+  });
+
+  const res = await fetch(`${url}/api/auth/callback/oidc?state=${state}`, {
+    redirect: "manual",
+  });
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toContain("/login?error=missing_params");
+});
+
+test("GET /callback/oidc with invalid state returns error", async () => {
+  const { url } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+    },
+  });
+
+  const res = await fetch(
+    `${url}/api/auth/callback/oidc?code=test-code&state=invalid-state`,
+    {
+      redirect: "manual",
+    }
+  );
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toContain("/login?error=invalid_state");
+});
+
+test("GET /callback/oidc creates new user on successful authentication", async () => {
+  const { url, bindings } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+    },
+  });
+
+  // Mock OIDC endpoints
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    ),
+    http.post("https://issuer.example.com/token", () => {
+      return HttpResponse.json(mockOIDCTokenResponse);
+    }),
+    http.get("https://issuer.example.com/userinfo", () => {
+      return HttpResponse.json(mockOIDCProfile);
+    })
+  );
+
+  const { encode } = await import("next-auth/jwt");
+  const state = await encode({
+    secret: bindings.AUTH_SECRET,
+    salt: "oauth-state",
+    token: {
+      provider: "oidc",
+      nonce: "test-nonce",
+      callbackUrl: `${url}/api/auth/callback/oidc`,
+    },
+  });
+
+  const res = await fetch(
+    `${url}/api/auth/callback/oidc?code=test-code&state=${state}`,
+    {
+      redirect: "manual",
+    }
+  );
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toBe("/chat");
+
+  // Check session cookie was set
+  const cookies = res.headers.get("Set-Cookie");
+  expect(cookies).toContain("blink_session_token=");
+  expect(cookies).toContain("last_login_provider=oidc");
+});
+
+test("GET /callback/oidc uses custom email claim field", async () => {
+  const customProfile = {
+    sub: "oidc-custom-user",
+    custom_email: "custom@example.com",
+    name: "Custom User",
+    email_verified: true,
+  };
+
+  const { url, bindings } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+      OIDC_EMAIL_FIELD: "custom_email",
+    },
+  });
+
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    ),
+    http.post("https://issuer.example.com/token", () => {
+      return HttpResponse.json(mockOIDCTokenResponse);
+    }),
+    http.get("https://issuer.example.com/userinfo", () => {
+      return HttpResponse.json(customProfile);
+    })
+  );
+
+  const { encode } = await import("next-auth/jwt");
+  const state = await encode({
+    secret: bindings.AUTH_SECRET,
+    salt: "oauth-state",
+    token: {
+      provider: "oidc",
+      nonce: "test-nonce",
+      callbackUrl: `${url}/api/auth/callback/oidc`,
+    },
+  });
+
+  const res = await fetch(
+    `${url}/api/auth/callback/oidc?code=test-code&state=${state}`,
+    {
+      redirect: "manual",
+    }
+  );
+
+  expect(res.status).toBe(302);
+  expect(res.headers.get("Location")).toBe("/chat");
+});
+
+test("GET /callback/oidc rejects unverified email by default", async () => {
+  const unverifiedProfile = {
+    ...mockOIDCProfile,
+    email_verified: false,
+  };
+
+  const { url, bindings } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+    },
+  });
+
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    ),
+    http.post("https://issuer.example.com/token", () => {
+      return HttpResponse.json(mockOIDCTokenResponse);
+    }),
+    http.get("https://issuer.example.com/userinfo", () => {
+      return HttpResponse.json(unverifiedProfile);
+    })
+  );
+
+  const { encode } = await import("next-auth/jwt");
+  const state = await encode({
+    secret: bindings.AUTH_SECRET,
+    salt: "oauth-state",
+    token: {
+      provider: "oidc",
+      nonce: "test-nonce",
+      callbackUrl: `${url}/api/auth/callback/oidc`,
+    },
+  });
+
+  const res = await fetch(
+    `${url}/api/auth/callback/oidc?code=test-code&state=${state}`,
+    {
+      redirect: "manual",
+    }
+  );
+
+  expect(res.status).toBe(302);
+  const location = res.headers.get("Location");
+  expect(location).toContain("/login?error=email_not_verified");
+});
+
+test("GET /callback/oidc accepts unverified email when OIDC_IGNORE_EMAIL_VERIFIED=true", async () => {
+  const unverifiedProfile = {
+    ...mockOIDCProfile,
+    sub: "oidc-unverified-user",
+    email: "unverified@example.com",
+    email_verified: false,
+  };
+
+  const { url, bindings } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+      OIDC_IGNORE_EMAIL_VERIFIED: true,
+    },
+  });
+
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    ),
+    http.post("https://issuer.example.com/token", () => {
+      return HttpResponse.json(mockOIDCTokenResponse);
+    }),
+    http.get("https://issuer.example.com/userinfo", () => {
+      return HttpResponse.json(unverifiedProfile);
+    })
+  );
+
+  const { encode } = await import("next-auth/jwt");
+  const state = await encode({
+    secret: bindings.AUTH_SECRET,
+    salt: "oauth-state",
+    token: {
+      provider: "oidc",
+      nonce: "test-nonce",
+      callbackUrl: `${url}/api/auth/callback/oidc`,
+    },
+  });
+
+  const res = await fetch(
+    `${url}/api/auth/callback/oidc?code=test-code&state=${state}`,
+    {
+      redirect: "manual",
+    }
+  );
+
+  expect(res.status).toBe(302);
+  expect(res.headers.get("Location")).toBe("/chat");
+});
+
+test("GET /callback/oidc returns existing user if already registered", async () => {
+  const { url, bindings, helpers } = await serve({
+    bindings: {
+      OIDC_ISSUER_URL: "https://issuer.example.com",
+      OIDC_CLIENT_ID: "test-oidc-client-id",
+      OIDC_CLIENT_SECRET: "test-oidc-client-secret",
+    },
+  });
+
+  // Create existing user with OIDC provider
+  const { user } = await helpers.createUser({
+    email: "existing-oidc@example.com",
+    display_name: "Existing OIDC User",
+  });
+
+  const db = await bindings.database();
+  await db.upsertUserAccount({
+    user_id: user.id,
+    type: "oauth",
+    provider: "oidc",
+    provider_account_id: "oidc-existing-user",
+    access_token: "old-token",
+    refresh_token: null,
+    expires_at: null,
+    token_type: null,
+    scope: null,
+    id_token: null,
+    session_state: "",
+  });
+
+  const existingProfile = {
+    sub: "oidc-existing-user",
+    email: "existing-oidc@example.com",
+    name: "Existing OIDC User",
+    email_verified: true,
+  };
+
+  mswServer.use(
+    http.get(
+      "https://issuer.example.com/.well-known/openid-configuration",
+      () => {
+        return HttpResponse.json(mockOIDCDiscovery);
+      }
+    ),
+    http.post("https://issuer.example.com/token", () => {
+      return HttpResponse.json(mockOIDCTokenResponse);
+    }),
+    http.get("https://issuer.example.com/userinfo", () => {
+      return HttpResponse.json(existingProfile);
+    })
+  );
+
+  const { encode } = await import("next-auth/jwt");
+  const state = await encode({
+    secret: bindings.AUTH_SECRET,
+    salt: "oauth-state",
+    token: {
+      provider: "oidc",
+      nonce: "test-nonce",
+      callbackUrl: `${url}/api/auth/callback/oidc`,
+    },
+  });
+
+  const res = await fetch(
+    `${url}/api/auth/callback/oidc?code=test-code&state=${state}`,
+    {
+      redirect: "manual",
+    }
+  );
+
+  expect(res.status).toBe(302);
+  expect(res.headers.get("Location")).toBe("/chat");
+});
+
 test("POST /resend-password-reset fails for non-existent user", async () => {
   const { url, bindings } = await serve();
 

--- a/internal/api/src/routes/auth/auth.server.ts
+++ b/internal/api/src/routes/auth/auth.server.ts
@@ -47,7 +47,105 @@ const providers = {
     userUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
     scope: "openid email profile",
   },
+  // OIDC provider is dynamically configured via environment variables
+  oidc: {
+    id: "oidc",
+    name: "OpenID Connect",
+    type: "oidc" as const,
+  },
 };
+
+// ============================================================================
+// OIDC Discovery
+// ============================================================================
+
+/**
+ * OIDC discovery configuration cache.
+ * Cached per issuer URL to avoid repeated discovery requests.
+ */
+const oidcDiscoveryCache = new Map<
+  string,
+  {
+    config: OIDCDiscoveryConfig;
+    expiresAt: number;
+  }
+>();
+
+interface OIDCDiscoveryConfig {
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  issuer: string;
+}
+
+/**
+ * Fetch and cache OIDC discovery configuration from the issuer's
+ * .well-known/openid-configuration endpoint.
+ */
+async function discoverOIDCEndpoints(
+  issuerUrl: string
+): Promise<OIDCDiscoveryConfig> {
+  // Check cache first (cache for 1 hour)
+  const cached = oidcDiscoveryCache.get(issuerUrl);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.config;
+  }
+
+  // Normalize issuer URL (remove trailing slash)
+  const normalizedIssuer = issuerUrl.replace(/\/$/, "");
+  const discoveryUrl = `${normalizedIssuer}/.well-known/openid-configuration`;
+
+  const res = await fetch(discoveryUrl, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `OIDC discovery failed: ${res.status} ${res.statusText} from ${discoveryUrl}`
+    );
+  }
+
+  const config = (await res.json()) as OIDCDiscoveryConfig;
+
+  // Validate required fields
+  if (
+    !config.authorization_endpoint ||
+    !config.token_endpoint ||
+    !config.userinfo_endpoint
+  ) {
+    throw new Error("OIDC discovery response missing required endpoints");
+  }
+
+  // Cache the result for 1 hour
+  oidcDiscoveryCache.set(issuerUrl, {
+    config,
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  });
+
+  return config;
+}
+
+/**
+ * Extract a claim value from OIDC userinfo response using a field path.
+ * Supports nested fields with dot notation (e.g., "profile.email").
+ */
+function extractOIDCClaim(
+  profile: Record<string, unknown>,
+  field: string
+): string | undefined {
+  const parts = field.split(".");
+  let value: unknown = profile;
+  for (const part of parts) {
+    if (value && typeof value === "object") {
+      value = (value as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof value === "string" ? value : undefined;
+}
 
 // ============================================================================
 // Helpers
@@ -411,6 +509,396 @@ async function handleOAuthCallback(
 }
 
 // ============================================================================
+// OIDC Flow
+// ============================================================================
+
+async function initiateOIDCFlow(c: Context<{ Bindings: Bindings }>) {
+  const issuerUrl = c.env.OIDC_ISSUER_URL;
+  const clientId = c.env.OIDC_CLIENT_ID;
+
+  if (!issuerUrl || !clientId) {
+    return c.redirect("/login?error=oidc_not_configured");
+  }
+
+  // Discover OIDC endpoints
+  let discovery: OIDCDiscoveryConfig;
+  try {
+    discovery = await discoverOIDCEndpoints(issuerUrl);
+  } catch (err) {
+    console.error("OIDC discovery failed:", err);
+    return c.redirect("/login?error=oidc_discovery_failed");
+  }
+
+  const callbackUrl = new URL(`/api/auth/callback/oidc`, c.env.apiBaseURL);
+
+  // Generate state with encoded redirect info
+  const state = await encode({
+    secret: c.env.AUTH_SECRET,
+    salt: "oauth-state",
+    token: {
+      provider: "oidc",
+      nonce: crypto.randomUUID(),
+      callbackUrl: callbackUrl.toString(),
+    },
+  });
+
+  const authUrl = new URL(discovery.authorization_endpoint);
+  const scopes = c.env.OIDC_SCOPES || "openid profile email";
+
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", callbackUrl.toString());
+  authUrl.searchParams.set("scope", scopes);
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set("response_type", "code");
+
+  // Apply any extra auth URL parameters
+  if (c.env.OIDC_AUTH_URL_PARAMS) {
+    try {
+      const extraParams = JSON.parse(c.env.OIDC_AUTH_URL_PARAMS) as Record<
+        string,
+        string
+      >;
+      for (const [key, value] of Object.entries(extraParams)) {
+        authUrl.searchParams.set(key, value);
+      }
+    } catch {
+      console.error("Failed to parse OIDC_AUTH_URL_PARAMS");
+    }
+  }
+
+  return c.redirect(authUrl.toString());
+}
+
+async function handleOIDCCallback(c: Context<{ Bindings: Bindings }>) {
+  const code = c.req.query("code");
+  const state = c.req.query("state");
+
+  if (!code || !state) {
+    return c.redirect("/login?error=missing_params");
+  }
+
+  const issuerUrl = c.env.OIDC_ISSUER_URL;
+  const clientId = c.env.OIDC_CLIENT_ID;
+  const clientSecret = c.env.OIDC_CLIENT_SECRET;
+
+  if (!issuerUrl || !clientId || !clientSecret) {
+    return c.redirect("/login?error=oidc_not_configured");
+  }
+
+  // Verify state
+  try {
+    const decoded = await decode({
+      token: state,
+      secret: c.env.AUTH_SECRET,
+      salt: "oauth-state",
+    });
+
+    if (!decoded || decoded.provider !== "oidc") {
+      return c.redirect("/login?error=invalid_state");
+    }
+  } catch {
+    return c.redirect("/login?error=invalid_state");
+  }
+
+  // Discover OIDC endpoints
+  let discovery: OIDCDiscoveryConfig;
+  try {
+    discovery = await discoverOIDCEndpoints(issuerUrl);
+  } catch (err) {
+    console.error("OIDC discovery failed:", err);
+    return c.redirect("/login?error=oidc_discovery_failed");
+  }
+
+  const callbackUrl = new URL(`/api/auth/callback/oidc`, c.env.apiBaseURL);
+
+  // Exchange code for token
+  const tokenResponse = await fetch(discovery.token_endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      redirect_uri: callbackUrl.toString(),
+      grant_type: "authorization_code",
+    }),
+  });
+
+  const tokenData = (await tokenResponse.json()) as any;
+  const accessToken = tokenData.access_token;
+
+  if (!accessToken) {
+    console.error("OIDC token exchange failed:", tokenData);
+    return c.redirect("/login?error=no_access_token");
+  }
+
+  // Fetch user profile from userinfo endpoint
+  const userResponse = await fetch(discovery.userinfo_endpoint, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!userResponse.ok) {
+    const responseText = await userResponse.text();
+    console.error("Failed to fetch OIDC user profile", responseText);
+    return c.redirect("/login?error=failed_to_fetch_user_profile");
+  }
+
+  const profile = (await userResponse.json()) as Record<string, unknown>;
+
+  // Extract user info using configurable claim fields
+  const emailField = c.env.OIDC_EMAIL_FIELD || "email";
+  const usernameField = c.env.OIDC_USERNAME_FIELD || "preferred_username";
+
+  const email = extractOIDCClaim(profile, emailField);
+  const username =
+    extractOIDCClaim(profile, usernameField) ||
+    extractOIDCClaim(profile, "name") ||
+    extractOIDCClaim(profile, "nickname");
+
+  // Get subject identifier - required by OIDC spec
+  const sub = profile.sub as string;
+  if (!sub) {
+    console.error("OIDC profile missing sub claim:", profile);
+    return c.redirect("/login?error=invalid_oidc_profile");
+  }
+
+  // Check email verification unless explicitly ignored
+  if (!c.env.OIDC_IGNORE_EMAIL_VERIFIED) {
+    const emailVerified = profile.email_verified;
+    if (emailVerified === false) {
+      return c.redirect("/login?error=email_not_verified");
+    }
+  }
+
+  const userProfile = {
+    id: sub,
+    email: email || null,
+    name: username || null,
+    image: extractOIDCClaim(profile, "picture") || null,
+  };
+
+  const db = await c.env.database();
+  const inviteCookie = getCookie(c, INVITE_COOKIE);
+
+  // Check if user is already authenticated (for account linking)
+  const existingSessionToken = getCookie(c, SESSION_COOKIE_NAME);
+  let authenticatedUserId: string | null = null;
+
+  if (existingSessionToken) {
+    try {
+      const decoded = await decode({
+        token: existingSessionToken,
+        secret: c.env.AUTH_SECRET,
+        salt: SESSION_COOKIE_NAME,
+      });
+      if (decoded?.id) {
+        authenticatedUserId = decoded.id as string;
+      }
+    } catch {
+      // Invalid token, ignore
+    }
+  }
+
+  // Get or create user
+  const existingAccount = await db.selectUserAccountByProviderAccountID(
+    "oidc" as UserAccount["provider"],
+    userProfile.id
+  );
+
+  let user: User;
+  let isLinking = false;
+
+  if (existingAccount?.user) {
+    user = existingAccount.user;
+  } else if (authenticatedUserId) {
+    isLinking = true;
+    // User is already logged in - link this provider to their account
+    const existingUser = await db.selectUserByID(authenticatedUserId);
+    if (!existingUser) {
+      return c.redirect("/login?error=invalid_session");
+    }
+
+    // Check if this provider account is already linked to a different user
+    const conflictingAccount = await db.selectUserAccountByProviderAccountID(
+      "oidc" as UserAccount["provider"],
+      userProfile.id
+    );
+    if (
+      conflictingAccount &&
+      conflictingAccount.user.id !== authenticatedUserId
+    ) {
+      return c.redirect("/login?error=provider_already_linked&provider=oidc");
+    }
+
+    // Link the provider account to the existing user
+    await db.upsertUserAccount({
+      user_id: authenticatedUserId,
+      type: "oauth",
+      provider: "oidc" as UserAccount["provider"],
+      provider_account_id: userProfile.id,
+      access_token: accessToken,
+      refresh_token: tokenData.refresh_token ?? null,
+      expires_at: tokenData.expires_in
+        ? Math.floor(Date.now() / 1000) + tokenData.expires_in
+        : null,
+      token_type: tokenData.token_type ?? null,
+      scope: tokenData.scope ?? null,
+      id_token: tokenData.id_token ?? null,
+      session_state: "",
+    });
+
+    user = existingUser;
+  } else {
+    // Check if email is already in use by another account
+    if (userProfile.email) {
+      const existingUserByEmail = await db.selectUserByEmail(userProfile.email);
+      if (existingUserByEmail) {
+        return c.redirect(
+          "/login?error=email_already_in_use&email=" +
+            encodeURIComponent(userProfile.email)
+        );
+      }
+    }
+    // Create new user
+    let usedInviteId: string | null = null;
+
+    if (inviteCookie) {
+      // marker is the invite token itself, re-validate before using
+      const inviteData =
+        await db.selectOrganizationInviteWithOrganizationByToken(inviteCookie);
+      if (inviteData) {
+        const invite = inviteData.organization_invite;
+        if (
+          !(invite.expires_at && new Date() > invite.expires_at) &&
+          (invite.reusable || !invite.last_accepted_at)
+        ) {
+          usedInviteId = invite.id;
+        }
+      }
+    }
+
+    user = await db.insertUser({
+      email: userProfile.email,
+      email_verified: new Date(),
+      display_name: userProfile.name,
+      password: null,
+    });
+
+    // Auto-join team organizations (self-hosted mode)
+    if (c.env.autoJoinOrganizations) {
+      const teamOrgs = await db.selectTeamOrganizations();
+      if (teamOrgs.length === 0) {
+        // First user: create default org, make them owner
+        await db.insertOrganizationWithMembership({
+          name: "default",
+          kind: "organization",
+          created_by: user.id,
+        });
+      } else {
+        // Subsequent users: add as member to all existing team orgs
+        for (const org of teamOrgs) {
+          await db.insertOrganizationMembership({
+            organization_id: org.id,
+            user_id: user.id,
+            role: "member",
+          });
+        }
+      }
+    }
+
+    // consume single-use invite (mark accepted)
+    if (usedInviteId) {
+      try {
+        await db.updateOrganizationInviteLastAcceptedAtByID(usedInviteId);
+      } catch {}
+    }
+
+    // Link account
+    await db.upsertUserAccount({
+      user_id: user.id,
+      type: "oauth",
+      provider: "oidc" as UserAccount["provider"],
+      provider_account_id: userProfile.id,
+      access_token: accessToken,
+      refresh_token: tokenData.refresh_token ?? null,
+      expires_at: tokenData.expires_in
+        ? Math.floor(Date.now() / 1000) + tokenData.expires_in
+        : null,
+      token_type: tokenData.token_type ?? null,
+      scope: tokenData.scope ?? null,
+      id_token: tokenData.id_token ?? null,
+      session_state: "",
+    });
+
+    // Sync OAuth user to telemetry system (async, don't block)
+    if (c.env.sendTelemetryEvent && user.email) {
+      c.env
+        .sendTelemetryEvent({
+          type: "user.oauth_registered",
+          userId: user.id,
+          email: user.email,
+          name: user.display_name,
+          provider: "oidc",
+        })
+        .then(() => {
+          // Attempt to merge any existing invited user record
+          if (user!.email && c.env.sendTelemetryEvent) {
+            return c.env.sendTelemetryEvent({
+              type: "user.merged",
+              primaryUserId: user!.id,
+              secondaryUserId: user!.email,
+            });
+          }
+        })
+        .catch(() => {
+          // Ignore errors to avoid breaking OAuth flow
+        });
+    }
+  }
+
+  const token = await encode({
+    secret: c.env.AUTH_SECRET,
+    token: {
+      sub: user.id,
+      id: user.id,
+      email: user.email,
+      name: user.display_name,
+    },
+    salt: SESSION_COOKIE_NAME,
+  });
+
+  // Set cookies and redirect using Hono's setCookie helper
+  setCookie(c, SESSION_COOKIE_NAME, token, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "Lax",
+    secure: SESSION_SECURE,
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  });
+
+  setCookie(c, "last_login_provider", "oidc", {
+    path: "/",
+    httpOnly: true,
+    sameSite: "Lax",
+    secure: SESSION_SECURE,
+    maxAge: 60 * 60 * 24 * 180, // 180 days
+  });
+
+  // If linking an existing account, redirect back with success message
+  if (isLinking) {
+    return c.redirect("/chat?linked=oidc");
+  }
+
+  return c.redirect("/chat");
+}
+
+// ============================================================================
 // Routes
 // ============================================================================
 
@@ -509,16 +997,34 @@ export default function mountAuth(server: APIServer) {
   // GET /providers - List available providers
   server.get("/providers", (c) => {
     // Return only public fields (id, name, type) for each provider
-    const publicProviders = Object.fromEntries(
-      Object.entries(providers).map(([key, provider]) => [
-        key,
-        {
+    const publicProviders: Record<
+      string,
+      { id: string; name: string; type: string; signInText?: string; iconUrl?: string }
+    > = {};
+
+    for (const [key, provider] of Object.entries(providers)) {
+      // Skip OIDC if not configured
+      if (key === "oidc") {
+        if (!c.env.OIDC_ISSUER_URL || !c.env.OIDC_CLIENT_ID) {
+          continue;
+        }
+        // Use customized name/icon for OIDC if configured
+        publicProviders[key] = {
+          id: provider.id,
+          name: c.env.OIDC_SIGN_IN_TEXT || provider.name,
+          type: provider.type,
+          signInText: c.env.OIDC_SIGN_IN_TEXT,
+          iconUrl: c.env.OIDC_ICON_URL,
+        };
+      } else {
+        publicProviders[key] = {
           id: provider.id,
           name: provider.name,
           type: provider.type,
-        },
-      ])
-    );
+        };
+      }
+    }
+
     return c.json(publicProviders);
   });
 
@@ -688,6 +1194,16 @@ export default function mountAuth(server: APIServer) {
   // GET /callback/google - Handle Google OAuth callback
   server.get("/callback/google", async (c) => {
     return handleOAuthCallback(c, "google");
+  });
+
+  // GET /signin/oidc - Initiate generic OIDC OAuth
+  server.get("/signin/oidc", async (c) => {
+    return initiateOIDCFlow(c);
+  });
+
+  // GET /callback/oidc - Handle generic OIDC callback
+  server.get("/callback/oidc", async (c) => {
+    return handleOIDCCallback(c);
   });
 
   // POST /signout - Clear session

--- a/internal/api/src/routes/auth/auth.server.ts
+++ b/internal/api/src/routes/auth/auth.server.ts
@@ -79,11 +79,26 @@ interface OIDCDiscoveryConfig {
 }
 
 /**
+ * OAuth2 Authorization Server Metadata (RFC 8414).
+ * Used as fallback when OIDC discovery is not available.
+ */
+interface OAuth2ASMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint?: string; // Not in RFC 8414 but some servers include it
+}
+
+/**
  * Fetch and cache OIDC discovery configuration from the issuer's
  * .well-known/openid-configuration endpoint.
+ *
+ * Falls back to OAuth2 Authorization Server Metadata (.well-known/oauth-authorization-server)
+ * if OIDC discovery fails.
  */
 async function discoverOIDCEndpoints(
-  issuerUrl: string
+  issuerUrl: string,
+  userinfoEndpointOverride?: string
 ): Promise<OIDCDiscoveryConfig> {
   // Check cache first (cache for 1 hour)
   const cached = oidcDiscoveryCache.get(issuerUrl);
@@ -93,21 +108,63 @@ async function discoverOIDCEndpoints(
 
   // Normalize issuer URL (remove trailing slash)
   const normalizedIssuer = issuerUrl.replace(/\/$/, "");
-  const discoveryUrl = `${normalizedIssuer}/.well-known/openid-configuration`;
 
-  const res = await fetch(discoveryUrl, {
-    headers: {
-      Accept: "application/json",
-    },
-  });
+  // Try OIDC discovery first
+  const oidcDiscoveryUrl = `${normalizedIssuer}/.well-known/openid-configuration`;
+  let config: OIDCDiscoveryConfig | null = null;
 
-  if (!res.ok) {
-    throw new Error(
-      `OIDC discovery failed: ${res.status} ${res.statusText} from ${discoveryUrl}`
-    );
+  try {
+    const res = await fetch(oidcDiscoveryUrl, {
+      headers: { Accept: "application/json" },
+    });
+
+    if (res.ok) {
+      const contentType = res.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        const json = (await res.json()) as OIDCDiscoveryConfig;
+        if (json.authorization_endpoint && json.token_endpoint) {
+          config = json;
+        }
+      }
+    }
+  } catch {
+    // OIDC discovery failed, will try OAuth2 AS metadata next
   }
 
-  const config = (await res.json()) as OIDCDiscoveryConfig;
+  // Fallback to OAuth2 Authorization Server Metadata (RFC 8414)
+  if (!config) {
+    const oauth2AsUrl = `${normalizedIssuer}/.well-known/oauth-authorization-server`;
+    try {
+      const res = await fetch(oauth2AsUrl, {
+        headers: { Accept: "application/json" },
+      });
+
+      if (res.ok) {
+        const json = (await res.json()) as OAuth2ASMetadata;
+        if (json.authorization_endpoint && json.token_endpoint) {
+          // OAuth2 AS metadata doesn't require userinfo_endpoint
+          // Use override if provided, otherwise try common paths
+          config = {
+            issuer: json.issuer,
+            authorization_endpoint: json.authorization_endpoint,
+            token_endpoint: json.token_endpoint,
+            userinfo_endpoint:
+              userinfoEndpointOverride ||
+              json.userinfo_endpoint ||
+              `${normalizedIssuer}/api/v2/users/me`, // Common fallback for Coder-like servers
+          };
+        }
+      }
+    } catch {
+      // OAuth2 AS metadata also failed
+    }
+  }
+
+  if (!config) {
+    throw new Error(
+      `OIDC/OAuth2 discovery failed: Could not fetch configuration from ${normalizedIssuer}`
+    );
+  }
 
   // Validate required fields
   if (
@@ -520,13 +577,28 @@ async function initiateOIDCFlow(c: Context<{ Bindings: Bindings }>) {
     return c.redirect("/login?error=oidc_not_configured");
   }
 
-  // Discover OIDC endpoints
+  // Check for manual endpoint configuration first
   let discovery: OIDCDiscoveryConfig;
-  try {
-    discovery = await discoverOIDCEndpoints(issuerUrl);
-  } catch (err) {
-    console.error("OIDC discovery failed:", err);
-    return c.redirect("/login?error=oidc_discovery_failed");
+  if (c.env.OIDC_AUTH_ENDPOINT && c.env.OIDC_TOKEN_ENDPOINT) {
+    // Manual endpoint configuration - bypass discovery
+    discovery = {
+      issuer: issuerUrl,
+      authorization_endpoint: c.env.OIDC_AUTH_ENDPOINT,
+      token_endpoint: c.env.OIDC_TOKEN_ENDPOINT,
+      userinfo_endpoint:
+        c.env.OIDC_USERINFO_ENDPOINT || `${issuerUrl}/userinfo`,
+    };
+  } else {
+    // Auto-discover OIDC endpoints
+    try {
+      discovery = await discoverOIDCEndpoints(
+        issuerUrl,
+        c.env.OIDC_USERINFO_ENDPOINT
+      );
+    } catch (err) {
+      console.error("OIDC discovery failed:", err);
+      return c.redirect("/login?error=oidc_discovery_failed");
+    }
   }
 
   const callbackUrl = new URL(`/api/auth/callback/oidc`, c.env.apiBaseURL);
@@ -600,13 +672,28 @@ async function handleOIDCCallback(c: Context<{ Bindings: Bindings }>) {
     return c.redirect("/login?error=invalid_state");
   }
 
-  // Discover OIDC endpoints
+  // Check for manual endpoint configuration first
   let discovery: OIDCDiscoveryConfig;
-  try {
-    discovery = await discoverOIDCEndpoints(issuerUrl);
-  } catch (err) {
-    console.error("OIDC discovery failed:", err);
-    return c.redirect("/login?error=oidc_discovery_failed");
+  if (c.env.OIDC_AUTH_ENDPOINT && c.env.OIDC_TOKEN_ENDPOINT) {
+    // Manual endpoint configuration - bypass discovery
+    discovery = {
+      issuer: issuerUrl,
+      authorization_endpoint: c.env.OIDC_AUTH_ENDPOINT,
+      token_endpoint: c.env.OIDC_TOKEN_ENDPOINT,
+      userinfo_endpoint:
+        c.env.OIDC_USERINFO_ENDPOINT || `${issuerUrl}/userinfo`,
+    };
+  } else {
+    // Auto-discover OIDC endpoints
+    try {
+      discovery = await discoverOIDCEndpoints(
+        issuerUrl,
+        c.env.OIDC_USERINFO_ENDPOINT
+      );
+    } catch (err) {
+      console.error("OIDC discovery failed:", err);
+      return c.redirect("/login?error=oidc_discovery_failed");
+    }
   }
 
   const callbackUrl = new URL(`/api/auth/callback/oidc`, c.env.apiBaseURL);

--- a/internal/api/src/routes/auth/auth.server.ts
+++ b/internal/api/src/routes/auth/auth.server.ts
@@ -748,10 +748,10 @@ async function handleOIDCCallback(c: Context<{ Bindings: Bindings }>) {
     extractOIDCClaim(profile, "name") ||
     extractOIDCClaim(profile, "nickname");
 
-  // Get subject identifier - required by OIDC spec
-  const sub = profile.sub as string;
+  // Get subject identifier - OIDC uses "sub", but some OAuth2 providers use "id"
+  const sub = (profile.sub || profile.id) as string;
   if (!sub) {
-    console.error("OIDC profile missing sub claim:", profile);
+    console.error("OIDC profile missing sub/id claim:", profile);
     return c.redirect("/login?error=invalid_oidc_profile");
   }
 

--- a/internal/api/src/server.ts
+++ b/internal/api/src/server.ts
@@ -246,6 +246,11 @@ export interface Bindings {
   readonly OIDC_SIGN_IN_TEXT?: string; // Button text
   readonly OIDC_ICON_URL?: string; // Button icon
 
+  // Manual endpoint configuration (overrides discovery)
+  readonly OIDC_AUTH_ENDPOINT?: string; // Authorization endpoint URL
+  readonly OIDC_TOKEN_ENDPOINT?: string; // Token endpoint URL
+  readonly OIDC_USERINFO_ENDPOINT?: string; // Userinfo endpoint URL
+
   readonly serverVersion: string;
 
   /** When true, auto-add new users to all existing team organizations (self-hosted mode) */

--- a/internal/api/src/server.ts
+++ b/internal/api/src/server.ts
@@ -234,6 +234,18 @@ export interface Bindings {
   readonly GOOGLE_CLIENT_ID?: string;
   readonly GOOGLE_CLIENT_SECRET?: string;
 
+  // Generic OIDC provider settings
+  readonly OIDC_ISSUER_URL?: string;
+  readonly OIDC_CLIENT_ID?: string;
+  readonly OIDC_CLIENT_SECRET?: string;
+  readonly OIDC_SCOPES?: string; // Default: "openid profile email"
+  readonly OIDC_EMAIL_FIELD?: string; // Default: "email"
+  readonly OIDC_USERNAME_FIELD?: string; // Default: "preferred_username"
+  readonly OIDC_AUTH_URL_PARAMS?: string; // JSON string for extra params
+  readonly OIDC_IGNORE_EMAIL_VERIFIED?: boolean;
+  readonly OIDC_SIGN_IN_TEXT?: string; // Button text
+  readonly OIDC_ICON_URL?: string; // Button icon
+
   readonly serverVersion: string;
 
   /** When true, auto-add new users to all existing team organizations (self-hosted mode) */

--- a/internal/database/src/schema.ts
+++ b/internal/database/src/schema.ts
@@ -151,7 +151,7 @@ export const user_account = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     type: text("type").notNull(),
-    provider: text("provider").$type<"github" | "google" | "slack">().notNull(),
+    provider: text("provider").$type<"github" | "google" | "slack" | "oidc">().notNull(),
     provider_account_id: text("provider_account_id").notNull(),
     refresh_token: text("refresh_token"),
     access_token: text("access_token"),

--- a/internal/site/app/(public)/login/page.tsx
+++ b/internal/site/app/(public)/login/page.tsx
@@ -21,6 +21,28 @@ interface LoginPageProps {
   }>;
 }
 
+interface OIDCProvider {
+  id: string;
+  name: string;
+  type: string;
+  signInText?: string;
+  iconUrl?: string;
+}
+
+async function getOIDCProvider(): Promise<OIDCProvider | null> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL || "";
+    const res = await fetch(`${baseUrl}/api/auth/providers`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const providers = await res.json();
+    return providers.oidc || null;
+  } catch {
+    return null;
+  }
+}
+
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const {
     error,
@@ -37,7 +59,9 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     | "credentials"
     | "github"
     | "google"
+    | "oidc"
     | undefined;
+  const oidcProvider = await getOIDCProvider();
   return (
     <div className="flex items-center justify-center p-4">
       <div
@@ -148,6 +172,46 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
               </Button>
             </Link>
 
+            {/* OIDC Sign In - only shown when configured */}
+            {oidcProvider && (
+              <Link
+                href={`/api/auth/signin/oidc${redirectTarget ? `?redirect=${encodeURIComponent(redirectTarget)}` : ""}`}
+              >
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="w-full h-12 text-base font-medium group"
+                >
+                  <div className="flex items-center justify-center gap-3">
+                    {oidcProvider.iconUrl ? (
+                      <img
+                        src={oidcProvider.iconUrl}
+                        alt=""
+                        className="w-5 h-5"
+                      />
+                    ) : (
+                      <svg
+                        className="w-5 h-5"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+                      </svg>
+                    )}
+                    <span>
+                      {oidcProvider.signInText ||
+                        `Continue with ${oidcProvider.name}`}
+                    </span>
+                    {lastProvider === "oidc" ? (
+                      <Badge variant="secondary" className="ml-2">
+                        Last
+                      </Badge>
+                    ) : null}
+                  </div>
+                </Button>
+              </Link>
+            )}
+
             {/* Divider */}
             <div className="relative my-6">
               <div className="absolute inset-0 flex items-center">
@@ -210,6 +274,24 @@ function mapErrorToMessage(
       return "Sign-in is temporarily unavailable. Please try again later.";
     case "Verification":
       return "The verification link is invalid or has expired.";
+    case "oidc_not_configured":
+      return "OIDC authentication is not configured. Please contact your administrator.";
+    case "oidc_discovery_failed":
+      return "Failed to connect to the identity provider. Please try again later.";
+    case "email_not_verified":
+      return "Your email address has not been verified with the identity provider.";
+    case "invalid_oidc_profile":
+      return "Could not retrieve your profile from the identity provider.";
+    case "missing_params":
+      return "Authentication failed. Please try again.";
+    case "invalid_state":
+      return "Authentication session expired. Please try again.";
+    case "no_access_token":
+      return "Failed to authenticate with the identity provider.";
+    case "email_already_in_use":
+      return "This email is already associated with another account.";
+    case "provider_already_linked":
+      return "This identity provider account is already linked to another user.";
     default:
       return "Sign-in failed. Please try again.";
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -149,6 +149,19 @@ export async function startServer(options: ServerOptions) {
             serverVersion: pkg.version,
             ONBOARDING_AGENT_BUNDLE_URL:
               "https://artifacts.blink.host/starter-agent/bundle.tar.gz",
+
+            // OIDC provider configuration (from environment)
+            OIDC_ISSUER_URL: process.env.OIDC_ISSUER_URL,
+            OIDC_CLIENT_ID: process.env.OIDC_CLIENT_ID,
+            OIDC_CLIENT_SECRET: process.env.OIDC_CLIENT_SECRET,
+            OIDC_SCOPES: process.env.OIDC_SCOPES,
+            OIDC_EMAIL_FIELD: process.env.OIDC_EMAIL_FIELD,
+            OIDC_USERNAME_FIELD: process.env.OIDC_USERNAME_FIELD,
+            OIDC_AUTH_URL_PARAMS: process.env.OIDC_AUTH_URL_PARAMS,
+            OIDC_IGNORE_EMAIL_VERIFIED:
+              process.env.OIDC_IGNORE_EMAIL_VERIFIED === "true",
+            OIDC_SIGN_IN_TEXT: process.env.OIDC_SIGN_IN_TEXT,
+            OIDC_ICON_URL: process.env.OIDC_ICON_URL,
             agentStore: (deploymentTargetID) => {
               return {
                 delete: async (key) => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -162,6 +162,11 @@ export async function startServer(options: ServerOptions) {
               process.env.OIDC_IGNORE_EMAIL_VERIFIED === "true",
             OIDC_SIGN_IN_TEXT: process.env.OIDC_SIGN_IN_TEXT,
             OIDC_ICON_URL: process.env.OIDC_ICON_URL,
+
+            // Manual endpoint configuration (overrides discovery)
+            OIDC_AUTH_ENDPOINT: process.env.OIDC_AUTH_ENDPOINT,
+            OIDC_TOKEN_ENDPOINT: process.env.OIDC_TOKEN_ENDPOINT,
+            OIDC_USERINFO_ENDPOINT: process.env.OIDC_USERINFO_ENDPOINT,
             agentStore: (deploymentTargetID) => {
               return {
                 delete: async (key) => {


### PR DESCRIPTION
## Summary

Add support for any OpenID Connect provider (Okta, Auth0, Keycloak, Azure AD, etc.) similar to how Coder handles OIDC.

## Changes

- Add OIDC bindings to `Bindings` interface (`OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, etc.)
- Extend provider type in schema to include `'oidc'`
- Implement OIDC discovery with caching (`.well-known/openid-configuration`)
- Add `initiateOIDCFlow()` and `handleOIDCCallback()` functions
- Add configurable claim mapping for email/username extraction
- Add routes: `GET /signin/oidc` and `GET /callback/oidc`
- Update `/providers` endpoint to conditionally include OIDC when configured
- Wire up OIDC env vars in `packages/server` for self-hosted mode
- Add 14 comprehensive tests for OIDC functionality

## Configuration

| Variable | Required | Description |
|----------|----------|-------------|
| `OIDC_ISSUER_URL` | Yes | OIDC provider's issuer URL |
| `OIDC_CLIENT_ID` | Yes | OAuth client ID |
| `OIDC_CLIENT_SECRET` | Yes | OAuth client secret |
| `OIDC_SCOPES` | No | Scopes (default: `openid profile email`) |
| `OIDC_EMAIL_FIELD` | No | Claim for email (default: `email`) |
| `OIDC_USERNAME_FIELD` | No | Claim for username (default: `preferred_username`) |
| `OIDC_IGNORE_EMAIL_VERIFIED` | No | Skip email verification check |
| `OIDC_AUTH_URL_PARAMS` | No | Extra auth URL params (JSON) |
| `OIDC_SIGN_IN_TEXT` | No | Custom button text |
| `OIDC_ICON_URL` | No | Custom button icon |

## Callback URL

```
https://<blink-domain>/api/auth/callback/oidc
```

## Testing

Added 14 tests covering:
- Provider listing (with/without OIDC, customization)
- Sign-in flow (redirect, custom scopes, extra params, not configured)
- Callback flow (missing code, invalid state, user creation, custom email field, email verification, existing user)

All new OIDC tests pass locally.