### PR TITLE
fix(site): fix chart axis tick labels showing as black

### DIFF
--- a/internal/site/components/ui/area-chart.tsx
+++ b/internal/site/components/ui/area-chart.tsx
@@ -688,7 +688,10 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
               hide={!showXAxis}
               dataKey={index}
               interval={startEndOnly ? "preserveStartEnd" : intervalType}
-              tick={{ transform: "translate(0, 6)" }}
+              tick={{
+                transform: "translate(0, 6)",
+                fill: "var(--muted-foreground)",
+              }}
               ticks={
                 startEndOnly
                   ? [data[0][index], data[data.length - 1][index]]
@@ -696,12 +699,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
               }
               fill=""
               stroke=""
-              className={cn(
-                // base
-                "text-xs",
-                // text fill
-                "fill-gray-500 dark:fill-gray-500"
-              )}
+              className="text-xs"
               tickLine={false}
               axisLine={false}
               minTickGap={tickGap}
@@ -725,15 +723,13 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>(
               tickLine={false}
               type="number"
               domain={yAxisDomain as AxisDomain}
-              tick={{ transform: "translate(-3, 0)" }}
+              tick={{
+                transform: "translate(-3, 0)",
+                fill: "var(--muted-foreground)",
+              }}
               fill=""
               stroke=""
-              className={cn(
-                // base
-                "text-xs",
-                // text fill
-                "fill-gray-500 dark:fill-gray-500"
-              )}
+              className="text-xs"
               tickFormatter={
                 type === "percent" ? valueToPercent : valueFormatter
               }


### PR DESCRIPTION
The XAxis and YAxis tick labels on the /usage page charts were rendering as black instead of the themed muted color.

Recharts propagates the `fill=""` prop as an inline SVG attribute on `<text>` elements. In Tailwind v4, utility classes live in a CSS `@layer`, which has lower cascade priority than unlayered SVG presentation attributes. So the `fill-gray-500` CSS class on the parent `<g>` was being overridden by the empty `fill` attribute on each `<text>` element, causing text to fall back to the SVG default fill (black).

Fix by passing `fill` directly through the `tick` prop object, which recharts applies as an SVG attribute on each `<text>` element. Uses `var(--muted-foreground)` so the color follows the light/dark theme automatically.

---
*PR generated with Coder Agents*