### PR TITLE
test(internal/site): initialize lexical input tests after DOM setup

### DIFF
--- a/internal/site/components/chat-message-input.test.tsx
+++ b/internal/site/components/chat-message-input.test.tsx
@@ -1,18 +1,19 @@
-// Load the core package first so Bun initializes Lexical's shared exports before @lexical/react.
-import "lexical";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { render, waitFor } from "@testing-library/react";
 import { Window } from "happy-dom";
-import {
-  ChatMessageInput,
-  type ChatMessageInputRef,
-} from "./chat-message-input";
+import type { ChatMessageInputRef } from "./chat-message-input";
 
-beforeAll(() => {
+let ChatMessageInput: typeof import("./chat-message-input").ChatMessageInput;
+
+beforeAll(async () => {
   globalThis.window = new Window() as any;
   globalThis.document = window.document;
   globalThis.MutationObserver = window.MutationObserver;
   globalThis.getComputedStyle = window.getComputedStyle;
+  globalThis.Text = window.Text;
+
+  await import("lexical");
+  ({ ChatMessageInput } = await import("./chat-message-input"));
 });
 
 afterAll(async () => {
@@ -24,6 +25,8 @@ afterAll(async () => {
   delete globalThis.MutationObserver;
   // @ts-expect-error
   delete globalThis.getComputedStyle;
+  // @ts-expect-error
+  delete globalThis.Text;
 });
 
 test("has initial value", async () => {

--- a/internal/site/components/chat-multimodal-input.test.tsx
+++ b/internal/site/components/chat-multimodal-input.test.tsx
@@ -1,21 +1,24 @@
-// Load the core package first so Bun initializes Lexical's shared exports before @lexical/react.
-import "lexical";
 import { afterAll, beforeAll, expect, mock, test } from "bun:test";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { Window } from "happy-dom";
 import type { UIAttachment } from "@/hooks/use-attachments";
 import type { ChatMessageInputRef } from "./chat-message-input";
-import {
-  ChatMultimodalInput,
-  getInputLocalStorageKey,
-} from "./chat-multimodal-input";
 import { PreviewAttachment } from "./preview-attachment";
 
-beforeAll(() => {
+let ChatMultimodalInput: typeof import("./chat-multimodal-input").ChatMultimodalInput;
+let getInputLocalStorageKey: typeof import("./chat-multimodal-input").getInputLocalStorageKey;
+
+beforeAll(async () => {
   globalThis.window = new Window() as any;
   globalThis.document = window.document;
   globalThis.MutationObserver = window.MutationObserver;
   globalThis.getComputedStyle = window.getComputedStyle;
+  globalThis.Text = window.Text;
+
+  await import("lexical");
+  ({ ChatMultimodalInput, getInputLocalStorageKey } = await import(
+    "./chat-multimodal-input"
+  ));
 });
 
 afterAll(async () => {
@@ -27,6 +30,8 @@ afterAll(async () => {
   delete globalThis.MutationObserver;
   // @ts-expect-error
   delete globalThis.getComputedStyle;
+  // @ts-expect-error
+  delete globalThis.Text;
 });
 
 test("loads input value from localStorage", async () => {


### PR DESCRIPTION
## Summary
- Initialize the Lexical input component tests after happy-dom globals are installed.
- Dynamically load the input components in the affected tests so Bun does not evaluate Lexical before the test DOM exists.
- Restore the additional global after each test file completes.

## Validation
- `bunx biome check internal/site/components/chat-multimodal-input.test.tsx internal/site/components/chat-message-input.test.tsx`
- `bunx bun@1.3.14 test internal/site/components/preview-attachment.test.tsx internal/site/components/message-actions.test.tsx internal/site/components/user-selector.test.tsx internal/site/components/chat-multimodal-input.test.tsx internal/site/components/markdown.test.tsx internal/site/components/chat-message-input.test.tsx`
- `bun run typecheck`
- `bun run format:check`

Generated by Coder Agents.
